### PR TITLE
Fix Photopea Editor Does Not Auto-Initialize on First Visit or Incogn…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,9 @@ class Photopea {
         frame.style.border = "0";
         frame.style.width = "100%";
         frame.style.height = "100%";
-        if (config) frame.src = "https://www.photopea.com#" + encodeURI(_config);
-        else frame.src = "https://www.photopea.com";
+        let rnd = Math.floor(Math.random()*899999999 + 100000000)
+        if (config) frame.src = `https://www.photopea.com?rnd=${rnd}#${encodeURI(_config)}`;
+        else frame.src = `https://www.photopea.com?rnd=${rnd}`;
         parentElement.appendChild(frame);
         let waitForInit = new Promise(function(res, rej) {
             let messageHandle = (e) => {


### PR DESCRIPTION
When accessing Photopea for the first time on a new device or in an incognito/private browsing window, the editor does not automatically launch. Instead, a welcome screen appears requiring the user to click a button to proceed. This behavior prevents the Photopea API from initializing the editor programmatically on first-time visits.

Steps to Reproduce:
- Open an incognito/private browsing window.
- Navigate to: https://www.photopea.com
- Observe that a welcome screen appears and manual interaction is required to open the editor.

Expected Behavior: The editor should launch immediately without requiring user interaction, especially for API integrations or embedded use cases.

Workaround: Append a random query parameter to the URL to bypass the welcome screen and directly load the editor:

Suggested Fix: Always include a random query parameter (e.g., rnd=<random_number>) in the URL to ensure the editor loads immediately, even on first-time or incognito sessions.
Check how they integrated the iframe in the playground example: https://www.photopea.com/api/playground

Impact: This issue blocks automatic initialization of Photopea via API on devices that haven't visited the site before, affecting user experience and automation workflows.